### PR TITLE
Add specific type and kind to techdocs

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,12 +1,12 @@
 ---
 apiVersion: backstage.io/v1alpha1
-kind: Component
+kind: Resource
 metadata:
   name: roadie-techdocs
   description: Used for roadie onboarding
   annotations:
     backstage.io/techdocs-ref: dir:./
 spec:
-  type: documentation
+  type: roadie-techdocs-documentation
   lifecycle: production
   owner: group:engineering


### PR DESCRIPTION
This might allow us to specify a very specific behaviour for the techdocs entity page.